### PR TITLE
Correct the solution for exercise 6 ch 18

### DIFF
--- a/solutions/chapter18/probability_and_statistics_functions.ipynb
+++ b/solutions/chapter18/probability_and_statistics_functions.ipynb
@@ -319,9 +319,7 @@
    },
    "outputs": [],
    "source": [
-    "x = randn(100,2)\n",
-    "rho = 0.5\n",
-    "x[:,1] = rho * x[:,0] + np.sqrt(1-rho**2) * x[:,1]"
+    "x = stats.multivariate_normal(cov=[[1, -0.5], [-0.5, 1]]).rvs(100)\n",
    ]
   },
   {


### PR DESCRIPTION
Change code to have  -.5 instead of .5 in covariance matrix. Also use more convenient SciPy function.

Can verify correctness via:
`np.cov(x[:, 0], x[:, 1]) `

(should be [[1, -.5], [-.5, 1]] )
